### PR TITLE
Remove comments with license names after licenses() statement

### DIFF
--- a/external/freetype.BUILD
+++ b/external/freetype.BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # FreeType License, zlib
+licenses(["notice"])
 
 # We can't just glob *.c, since Freetype has .c files that include other .c
 # files all over the place.  In order to simplify the process of listing them
@@ -104,7 +104,10 @@ cc_library(
         "src/**/*.h",
         "include/**/*.h",
     ]),
-    copts = ["-DFT2_BUILD_LIBRARY", "-UDEBUG"],
+    copts = [
+        "-DFT2_BUILD_LIBRARY",
+        "-UDEBUG",
+    ],
     includes = ["include"],
     textual_hdrs = glob(["src/**/*.c"]),
     visibility = ["//visibility:public"],

--- a/external/sdl2.BUILD
+++ b/external/sdl2.BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # zlib, portions BSD, MIT, PostgreSQL
+licenses(["notice"])
 
 # Common include paths
 sdl_includes = [

--- a/quic_trace/BUILD
+++ b/quic_trace/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 proto_library(
     name = "quic_trace_proto",

--- a/quic_trace/analysis/BUILD
+++ b/quic_trace/analysis/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 package(
     default_visibility = ["//visibility:public"],

--- a/third_party/fonts/BUILD
+++ b/third_party/fonts/BUILD
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["DroidSans.ttf"])

--- a/third_party/glew/BUILD
+++ b/third_party/glew/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # BSD, Mesa, MIT, SGI, Khronos
+licenses(["notice"])
 
 # The source version of GLEW 2.1.0 is a custom, reduced-size version that only
 # contains the extensions we need (otherwise, GLEW takes up more than a

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 cc_binary(
     name = "quic_trace_to_time_sequence_gnuplot",

--- a/tools/render/BUILD
+++ b/tools/render/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":data_blob.bzl", "cc_data_blob")


### PR DESCRIPTION
Those comments seem to make internal linters unhappy