### PR TITLE
Switch quic-trace to use Abseil logging

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,19 +17,9 @@ http_archive(
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.14.0.tar.gz"],
 )
 
-http_archive(
-    name = "com_github_gflags_gflags",
-    sha256 = "6e16c8bc91b1310a44f3965e616383dbda48f83e8c1eaa2370a215057b00cabe",
-    strip_prefix = "gflags-77592648e3f3be87d6c7123eb81cbad75f9aef5a",
-    urls = [
-        "https://mirror.bazel.build/github.com/gflags/gflags/archive/77592648e3f3be87d6c7123eb81cbad75f9aef5a.tar.gz",
-        "https://github.com/gflags/gflags/archive/77592648e3f3be87d6c7123eb81cbad75f9aef5a.tar.gz",
-    ],
-)
-
 git_repository(
     name = "com_google_absl",
-    commit = "143a27800eb35f4568b9be51647726281916aac9",
+    commit = "ff100974413ccdd24b361ff9eb7cc78efb0cee78",
     remote = "https://github.com/abseil/abseil-cpp.git",
 )
 
@@ -47,12 +37,6 @@ http_archive(
     sha256 = "ad7a7d2562c19ad2b71fa4ab2e76f9f52b3ee98096c0a7d7efbafc2617073c27",
     strip_prefix = "SDL2_ttf-2.0.14",
     urls = ["https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14.zip"],
-)
-
-git_repository(
-    name = "com_google_glog",
-    commit = "55cc27b6eca3d7906fc1a920ca95df7717deb4e7",
-    remote = "https://github.com/google/glog.git",
 )
 
 http_archive(

--- a/quic_trace/analysis/BUILD
+++ b/quic_trace/analysis/BUILD
@@ -24,6 +24,6 @@ cc_library(
     deps = [
         "//quic_trace:quic_trace_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_glog//:glog",
+        "@com_google_absl//absl/log",
     ],
 )

--- a/quic_trace/analysis/trace_numbering.h
+++ b/quic_trace/analysis/trace_numbering.h
@@ -17,12 +17,11 @@
 #ifndef THIRD_PARTY_QUIC_TRACE_LIB_ANALYSIS_TRACE_NUMBERING_H_
 #define THIRD_PARTY_QUIC_TRACE_LIB_ANALYSIS_TRACE_NUMBERING_H_
 
-#include <glog/logging.h>
-
 #include <cstdint>
 #include <unordered_map>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/log/log.h"
 #include "quic_trace/quic_trace.pb.h"
 
 namespace quic_trace {

--- a/tools/render/BUILD
+++ b/tools/render/BUILD
@@ -55,10 +55,11 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
-        "@com_google_glog//:glog",
         "@sdl2",
         "@sdl2_ttf",
     ],
@@ -82,9 +83,9 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
-        "@com_google_glog//:glog",
     ],
 )
 
@@ -96,8 +97,10 @@ cc_binary(
     deps = [
         ":render_program",
         "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:flags",
+        "@com_google_absl//absl/log:initialize",
         "@com_google_absl//absl/strings",
-        "@com_google_glog//:glog",
     ],
 )
 

--- a/tools/render/render_trace.cc
+++ b/tools/render/render_trace.cc
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "absl/flags/parse.h"
+#include "absl/log/initialize.h"
 #include "absl/strings/string_view.h"
 #include "google/protobuf/util/json_util.h"
 #include "tools/render/trace_program.h"
@@ -37,13 +38,13 @@ InputFormat GuessInputFileFormat(absl::string_view filename) {
 
 // render_trace renders the specified trace file using an OpenGL-based viewer.
 int main(int argc, char* argv[]) {
-  absl::ParseCommandLine(argc, argv);
-  google::InitGoogleLogging(argv[0]);
+  std::vector<char*> args = absl::ParseCommandLine(argc, argv);
+  absl::InitializeLog();
 
   CHECK_GE(argc, 2) << "Specify file path";
   auto trace = std::make_unique<quic_trace::Trace>();
   {
-    std::string filename(argv[1]);
+    std::string filename(args[1]);
     std::ifstream f(filename);
     switch (GuessInputFileFormat(filename)) {
       case INPUT_QTR: {

--- a/tools/render/sdl_util.cc
+++ b/tools/render/sdl_util.cc
@@ -58,7 +58,6 @@ OpenGlContext::OpenGlContext(SDL_Window* window) {
               LOG(INFO) << "[GL]: " << std::string(message, length);
               break;
             case GL_DEBUG_SEVERITY_NOTIFICATION:
-              VLOG(1) << "[GL]: " << std::string(message, length);
               break;
           }
         },

--- a/tools/render/sdl_util.h
+++ b/tools/render/sdl_util.h
@@ -23,8 +23,8 @@
 
 #include <memory>
 
-#include <glog/logging.h>
-#include <glog/stl_logging.h>
+#include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/memory/memory.h"
 
 namespace quic_trace {


### PR DESCRIPTION
Also fix a small bug in the command line parser for render_trace I found while testing.